### PR TITLE
Farabi/fix-depandabot-issues

### DIFF
--- a/.github/workflows/generate_preview_link.yml
+++ b/.github/workflows/generate_preview_link.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
         with:
-          node-version: 18.x
+          node-version: 20
 
       - name: Install dependencies
         uses: "deriv-com/shared-actions/.github/actions/npm_install@master"

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
         with:
-          node-version: 18.x
+          node-version: 20
       - name: Install dependencies
         uses: "./.github/actions/npm_install"
       - name: Build

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
         with:
-          node-version: 18.x
+          node-version: 20
       - name: Install dependencies
         uses: "./.github/actions/npm_install"
       - name: Build Staging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
         with:
-          node-version: 18.x
+          node-version: 20
       - name: Install dependencies
         uses: "./.github/actions/npm_install"
       - name: Build

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
         "mocha": "10.8.2",
         "mock-local-storage": "1.1.7",
         "mock-require": "^3.0.3",
-        "node-gettext": "3.0.0",
+        "node-gettext": "3.0.1",
         "postcss-scss": "4.0.9",
         "react-render-html": "0.6.0",
         "sass": "^1.77.6",
@@ -13694,16 +13694,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/mock-local-storage": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/mock-local-storage/-/mock-local-storage-1.1.7.tgz",
@@ -14062,9 +14052,9 @@
       }
     },
     "node_modules/node-gettext": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
-      "integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.1.tgz",
+      "integrity": "sha512-foI20qQAV22OlCeFIUZiXZutPbe23nGuDp7hLvK6PanhOYlUJIgLAUZa4MB5pX0J62dubOM/MYVhQ2aYTUPbhA==",
       "dev": true,
       "dependencies": {
         "lodash.get": "^4.4.2"
@@ -18245,16 +18235,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -20052,6 +20032,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {
@@ -21995,16 +21985,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -23317,12 +23297,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/webpack/node_modules/terser-webpack-plugin": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
@@ -23381,53 +23355,6 @@
         "uglify-js": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack/node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack/node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/websocket-driver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,7 @@
         "ws": "8.18.0"
       },
       "engines": {
-        "node": "18.x"
+        "node": ">=20"
       },
       "peerDependencies": {
         "circular-dependency-plugin": "5.2.2"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "mocha": "10.8.2",
     "mock-local-storage": "1.1.7",
     "mock-require": "^3.0.3",
-    "node-gettext": "3.0.0",
+    "node-gettext": "3.0.1",
     "postcss-scss": "4.0.9",
     "react-render-html": "0.6.0",
     "sass": "^1.77.6",
@@ -155,7 +155,7 @@
     "postcss": "8.5.10",
     "qs": "6.15.2",
     "select2": "4.0.6",
-    "serialize-javascript": "6.0.2",
+    "serialize-javascript": "7.0.5",
     "uuid": "11.1.1",
     "load-grunt-config": {
       "js-yaml": "4.1.1"

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     }
   },
   "engines": {
-    "node": "18.x"
+    "node": ">=20"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
This pull request updates the Node.js version used throughout the project from 18.x to 20, ensuring consistency across development, testing, and deployment workflows. It also upgrades a few dependencies in `package.json` to their latest versions for improved security and compatibility.

**Node.js version upgrades:**

* Updated the Node.js version in all GitHub Actions workflow files (`generate_preview_link.yml`, `release_production.yml`, `release_staging.yml`, `test.yml`) to use version 20 instead of 18.x.
* Changed the `engines.node` field in `package.json` to require Node.js version >=20.

**Dependency updates:**

* Upgraded `node-gettext` from version 3.0.0 to 3.0.1 in `package.json`.
* Upgraded `serialize-javascript` from version 6.0.2 to 7.0.5 in `package.json`.